### PR TITLE
Bugfix: UnityInput switch map with empty value

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "com.bagheads.konsole",
     "displayName": "Konsole",
     "author": { "name": "Bagheads", "url": "https://github.com/kitakun" },
-    "version": "1.0.3",
+    "version": "1.0.4",
     "unity": "2018.4",
     "description": "Provides an easy injectable ingame console",
     "keywords": [ "console" ],

--- a/src/Bagheads.UnityConsole/Components/KonsoleComponent.cs
+++ b/src/Bagheads.UnityConsole/Components/KonsoleComponent.cs
@@ -404,13 +404,22 @@ namespace Bagheads.UnityConsole.Components
                     TMP_InputField.OnDeselect(new BaseEventData(EventSystem.current));
                 }
 #endif
+                #define  KONSOLE_INPUT_SYSTEM
 #if KONSOLE_INPUT_SYSTEM
                 if (TryGetInternalComponent<UnityEngine.InputSystem.PlayerInput>(out var playerInput))
                 {
                     if (playerInput != null && playerInput.currentActionMap != null && _inputActionBefore != PlayerInputUtils.KONSOLE_ACTION_NAME)
                     {
                         // move back
-                        playerInput.SwitchOn(_inputActionBefore);
+                        if(!string.IsNullOrEmpty(_inputActionBefore))
+                        {
+                            playerInput.SwitchOn(_inputActionBefore);
+                        }
+                        else if(!string.IsNullOrEmpty(playerInput.defaultActionMap))
+                        {
+                            playerInput.SwitchOn(playerInput.defaultActionMap);
+                        }
+
                         _inputActionBefore = string.Empty;
                     }
                     else if (playerInput != null && playerInput.currentActionMap is {name: PlayerInputUtils.KONSOLE_ACTION_NAME})


### PR DESCRIPTION
We shouldn't assign empty string as control map